### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You probably want to use the nodes in `FlexibleMovement` directly.
 However, if you're not actually moving anything then you can try the `PathfinderSystem#requestPath` method.
 
 You can see the basic usage example in the
-[unit test helper](https://github.com/kaen/FlexiblePathfinding/blob/master/src/test/java/org/terasology/flexiblepathfinding/JPSTestHelper.java#L83-L99)
+[unit test helper](https://github.com/kaen/FlexiblePathfinding/blob/master/src/test/java/org/terasology/flexiblepathfinding/helpers/JPSTestHelper.java#L83-L99)
 
 # Hacking
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You probably want to use the nodes in `FlexibleMovement` directly.
 However, if you're not actually moving anything then you can try the `PathfinderSystem#requestPath` method.
 
 You can see the basic usage example in the
-[unit test helper](https://github.com/kaen/FlexiblePathfinding/blob/master/src/test/java/org/terasology/flexiblepathfinding/helpers/JPSTestHelper.java#L83-L99)
+[unit test helper](https://github.com/kaen/FlexiblePathfinding/blob/master/src/test/java/org/terasology/flexiblepathfinding/helpers/JPSTestHelper.java#L99-L116)
 
 # Hacking
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A plugin-based JPS pathfinder for Terasology.
 
 This is a clone of the [original repository by Kaen](https://github.com/kaen/FlexiblePathfinding).
 
-See also [FlexibleMovement](https://github.com/kaen/FlexibleMovement)
+See also [FlexibleMovement](https://github.com/Terasology/FlexibleMovement).
 
 # Usage
 


### PR DESCRIPTION
### Contains

Small documentation fixes on README:

- Corrected link for "unit test helper"
- Changed lines reference on "unit test helper" to focus on the runJps method
- Changed the FlexibleMovement link so it'd point to the equivalent Terasology repository

### How to test

- Go to the initial (README) page
- Check if the new "unit test helper" is working properly
- Check if the "unittest helper"link is pointing to lines 99-116
- Check if the FlexibleMovement repository is pointing to the one under the Terasology account

### Outstanding before merging

- [ ] Check if it makes sense to use the Terasology's repository as the new reference for FlexibleMovement 
- [ ] Check if the runJps method is the one intended to be used as usage example
